### PR TITLE
Infinite redirect loop fix in stelar ingress

### DIFF
--- a/lib/stelar_ingress.libsonnet
+++ b/lib/stelar_ingress.libsonnet
@@ -121,6 +121,7 @@ local ingress(pim, config, name, annotations, host, paths) =
             },
             host = config.endpoint.PRIMARY_SUBDOMAIN+'.'+config.endpoint.ROOT_DOMAIN, 
             paths = [
+                ["/", "Exact", "stelarapi", "apiserver-api"],
                 ["/(dc)(/|$)(.*)", "ImplementationSpecific", "ckan", "api"],
                 ["/(stelar)(/|$)(.*)", "ImplementationSpecific", "stelarapi", "apiserver-api"],
                 ["/(s3)(/|$)(.*)", "ImplementationSpecific", "minio", "minio-minio"],

--- a/lib/stelar_ingress.libsonnet
+++ b/lib/stelar_ingress.libsonnet
@@ -121,7 +121,6 @@ local ingress(pim, config, name, annotations, host, paths) =
             },
             host = config.endpoint.PRIMARY_SUBDOMAIN+'.'+config.endpoint.ROOT_DOMAIN, 
             paths = [
-                ["/", "Prefix", "stelarapi", "apiserver-api"],
                 ["/(dc)(/|$)(.*)", "ImplementationSpecific", "ckan", "api"],
                 ["/(stelar)(/|$)(.*)", "ImplementationSpecific", "stelarapi", "apiserver-api"],
                 ["/(s3)(/|$)(.*)", "ImplementationSpecific", "minio", "minio-minio"],


### PR DESCRIPTION
A Prefix / means
  "match anything that starts with /" — and since every URL starts with /, it matches everything.

  So with these two rules in the ingress:

  ["/",                        "Prefix",                 "stelarapi", ...]
  ["/(stelar)(/|$)(.*)",       "ImplementationSpecific", "stelarapi", ...]

  Both of them match a request for /stelar/console/v1/login. The question is which one NGINX picks.

  Normally regex (ImplementationSpecific) beats Prefix, so /(stelar)(/|$)(.*) should win. But the presence of
  the Prefix / creates ambiguity — NGINX ingress generates location blocks for all paths and the Prefix / acts
  as a fallback that can catch requests that slip through or are processed in an unexpected order.

  The practical consequence: with Prefix / present, a request for /stelar/console/v1/login might get handled by
  the Prefix / rule instead of the regex rule. When that happens:

  GET /stelar/console/v1/login
    matched by Prefix /
    rewrite-target /$3 — but Prefix / has no capture groups, $3 is empty
    stelarapi receives GET /
    Flask redirects to /stelar/console/v1/login
    matched by Prefix / again
    → loop

  Without Prefix /, only the ImplementationSpecific paths exist. /stelar/console/v1/login can only match
  /(stelar)(/|$)(.*), which captures $3 = console/v1/login correctly, so stelarapi receives GET
  /console/v1/login and serves the page.
